### PR TITLE
fix copy-paste error

### DIFF
--- a/content/en/posts/2022/09/huggins-roy-ess/index.md
+++ b/content/en/posts/2022/09/huggins-roy-ess/index.md
@@ -75,7 +75,7 @@ $$
 
 $$
 \operatorname{ESS}_{1}(\overline{\mathbf{w}}) =
-  \operatorname{exp} \Bigg( -\sum_{i=1}^n \overline{w}_i \log \overline{w}_i \Bigg)^2.
+  \operatorname{exp} \Bigg( -\sum_{i=1}^n \overline{w}_i \log \overline{w}_i \Bigg).
 $$
 
 This approach is also known as *perplexity*


### PR DESCRIPTION
The perplexity is defined without the square in the cited references. I reckon this was probably a copy-paste error.